### PR TITLE
Feature: move state to html and implement accessible status

### DIFF
--- a/art.css
+++ b/art.css
@@ -1,7 +1,28 @@
+:root {
+  --segment-size: 3rem;
+  --flask-top-size: 0.5rem;
+  --border-size: 0.1rem;
+  --flask-color: white;
+  --accent-color: dimgray;
+  --border-color: silver;
+}
+
+.visually-hidden {
+  width: 1px;
+  height: 1px;
+  font-size: 1px;
+  color: transparent;
+  pointer-events: none;
+  user-select: none;
+  overflow: hidden;
+  position: absolute;
+  z-index: -1;
+}
+
 #flasks {
   display: flex;
   flex-direction: row;
-  gap: 30px;
+  gap: var(--segment-size);
 }
 
 .flask {
@@ -10,41 +31,66 @@
   transition: transform 500ms;
   transform: rotate(0deg);
 
-  &.pouring {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding-block: calc((var(--flask-top-size) * 2) + (var(--border-size) * 3)) var(--border-size);
+  padding-inline: calc(var(--flask-top-size) + var(--border-size));
+
+  &[aria-pressed="true"] {
     transform: rotate(15deg);
   }
 
-  .segment {
-    width: 50px;
-    height: 50px;
-    border: 1px solid gray;
+  * {
+    pointer-events: none;
+  }
 
-    &[data-color="red"] {
+  ol {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .segment {
+    width: var(--segment-size);
+    height: var(--segment-size);
+
+    border: var(--border-size) solid var(--border-color);
+    border-block-start-color: transparent;
+    background: var(--flask-color);
+
+    &[data-color="red" i] {
       background-color: red;
     }
 
-    &[data-color="blue"] {
+    &[data-color="blue" i] {
       background-color: blue;
     }
 
-    &:first-child {
-      border-top-color: transparent;
-
-      &::before {
-        display: block;
-        margin-left: -10px;
-        content: "";
-        width: calc(100% + 20px);
-        height: 20px;
-        margin-top: -22px;
-        border-radius: 10px;
-        border: 1px solid gray;
-      }
+    &:first-child::before {
+      display: block;
+      content: "";
+      width: calc(100% + (var(--flask-top-size) * 2));
+      height: calc(var(--flask-top-size) * 2);
+      margin-inline-start: calc((var(--flask-top-size) * -1) - var(--border-size));
+      margin-block-start: calc((var(--flask-top-size) * -2) - (var(--border-size) * 2));
+      border-radius: var(--flask-top-size);
+      border: var(--border-size) solid var(--border-color);
+      background: var(--flask-color);
     }
 
     &:last-child {
-      border-bottom-left-radius: 50px;
-      border-bottom-right-radius: 50px;
+      border-bottom-left-radius: var(--segment-size);
+      border-bottom-right-radius: var(--segment-size);
     }
+  }
+
+  &:hover {
+    filter: drop-shadow(0 0 calc(var(--border-size) * 3) var(--accent-color));
+  }
+
+  &:focus {
+    outline: var(--border-size) dotted var(--accent-color);
+    filter: drop-shadow(0 0 calc(var(--border-size) * 3) var(--accent-color));
   }
 }

--- a/index.html
+++ b/index.html
@@ -1,38 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
+    <meta charset="utf-8" />
     <title>Water Sort</title>
-    <meta name="charset" value="utf-8" />
     <link rel="stylesheet" type="text/css" href="./art.css" />
   </head>
   <body>
     <h1>Water Sort</h1>
-    <pre><output id="output"></output></pre>
+    <output id="status" aria-live="polite" class="visually-hidden"></output>
     <div id="flasks">
       <!-- TODO-->
     </div>
-    <form>
-      <fieldset>
-        <legend>To flask</legend>
-        <label>
-          Flask 1
-          <input type="radio" name="to" value="0" />
-        </label>
-        <label>
-          Flask 2
-          <input type="radio" name="to" value="1" />
-        </label>
-        <label>
-          Flask 3
-          <input type="radio" name="to" value="2" />
-        </label>
-      </fieldset>
-
-      <button type="submit" id="test-button">Pour</button>
-    </form>
-
-    <dialog id="game-over">
-      <h2>You won!!!<h2>
+    <dialog id="game-over" aria-label="You won!">
+      <h2>You won!!!</h2>
     </dialog>
 
     <script src="./index.js" type="module" async defer></script>

--- a/index.js
+++ b/index.js
@@ -19,7 +19,33 @@ const gameData = [
   [],
 ];
 
-let selectedFromFlask = 0;
+const flasksContainer = document.getElementById("flasks");
+const statusContainer = document.getElementById('status');
+
+/**
+ *
+ * @param {'selected' | 'deselected' | 'pour' | 'failedToPour' | 'reset'} status
+ * @param {number} [fromIndex]
+ * @param {number} [toIndex]
+ */
+function updateStatus(status, fromIndex, toIndex) {
+  switch (status) {
+    case "selected":
+      statusContainer.innerHTML = `Flask ${fromIndex + 1} selected.`;
+      break;
+    case "deselected":
+      statusContainer.innerHTML = `Flask ${fromIndex + 1} deselected.`;
+      break;
+    case "pour":
+      statusContainer.innerHTML = `Poured from Flask ${fromIndex + 1} to Flask ${toIndex + 1}.`;
+      break;
+    case "failedToPour":
+      statusContainer.innerHTML = `Cannot pour from Flask ${fromIndex + 1} to Flask ${toIndex + 1}, select another flask.`;
+      break;
+    default:
+      statusContainer.innerHTML = 'Select a flask.'
+  }
+}
 
 /**
  * @param {Flask} from
@@ -52,103 +78,121 @@ function isSameColor(from, color) {
   return from.at(-1) === color;
 }
 
-function print() {
-  //  outputEl.innerHTML = JSON.stringify(gameData, null, 2);
-}
-
-const outputEl = document.getElementById("output");
-const flasksEl = document.getElementById("flasks");
-
-print();
-
-document.querySelector("form")?.addEventListener("submit", (evt) => {
-  evt.preventDefault();
-  evt.stopPropagation();
-
-  const target = evt.target;
-  const formData = new FormData(/** @type {HTMLFormElement} */ (target));
-
-  const from = selectedFromFlask;
-  const to = Number.parseInt(/** @type {string} */ (formData.get("to")));
-
-  pour(gameData[from], gameData[to]);
-  setFlaskOpen(null);
-  print();
-  updateFlasks();
-});
-
-document.querySelector("form").addEventListener("input", (evt) => {
-  const target = /** @type {HTMLInputElement}*/ (evt.target);
-
-  if (target.matches('input[type="radio"]')) {
-    if (target.hasAttribute("aria-disabled")) {
-      evt.preventDefault();
-      evt.stopPropagation();
-    }
-
-    const inputSelector = `input[type="radio"][name="to"]`;
-
-    document
-      .querySelectorAll(inputSelector)
-      .forEach((/** @type {HTMLInputElement}*/ input) => {
-        input.toggleAttribute("aria-disabled", false);
-      });
-
-    /** @type {HTMLInputElement}*/ (
-      document.querySelector(`${inputSelector}[value="${target.value}"]`)
-    ).toggleAttribute("aria-disabled", true);
-  }
-});
-
 /**
- * @param {number} flaskIndex
- * @returns {HTMLDivElement}
+ * @param {HTMLElement} flaskElement
+ * @param {Flask} flask
  */
-function renderFlask(flaskDiv, flask, flaskIndex) {
-  flaskDiv.replaceChildren();
-  for (let i = FLASK_SIZE - 1; i >= 0; i--) {
-    const segment = document.createElement("div");
-    segment.classList.add("segment");
-    segment.style.backgroundColor = flask[i];
-    flaskDiv.appendChild(segment);
+function renderFlask(flaskElement, flask) {
+  let list = flaskElement.querySelector("ol");
+
+  if (!list) {
+    list = document.createElement("ol");
+
+    const description = document.createElement("span");
+
+    description.classList.add('visually-hidden');
+    description.innerHTML = `Flask ${Number.parseInt(flaskElement.dataset.index) + 1}, ${FLASK_SIZE} parts.`;
+
+    flaskElement.appendChild(description);
   }
 
-  return flaskDiv;
+  list.replaceChildren();
+
+  for (let i = FLASK_SIZE - 1; i >= 0; i--) {
+    const segment = document.createElement("li");
+
+    segment.classList.add("segment");
+    segment.dataset.color = flask[i];
+    segment.ariaLabel = flask[i] ?? 'No color';
+
+    list.appendChild(segment);
+  }
+
+  flaskElement.appendChild(list);
 }
 
 function updateFlasks() {
-  const flaskElems = Array.from(document.querySelectorAll(".flask"));
+  const flaskElements = /** @type {HTMLElement[]} */ (Array.from(document.querySelectorAll(".flask")));
+
   for (let i = 0; i < gameData.length; i++) {
-    renderFlask(flaskElems[i], gameData[i], i);
+    renderFlask(flaskElements[i], gameData[i]);
   }
 }
 
 /**
- * @param {number|null} flaskIndex
+ * @param {HTMLElement} flaskElement
  */
-function setFlaskOpen(flaskIndex) {
-  selectedFromFlask = flaskIndex;
-  document.querySelectorAll(".flask").forEach((flask, idx) => {
-    if (idx === flaskIndex) {
-      flask.classList.add("pouring");
-    } else {
-      flask.classList.remove("pouring");
-    }
+function setFlaskOpen(flaskElement) {
+  flaskElement.setAttribute("aria-pressed", "true");
+  updateStatus("selected", Number.parseInt(flaskElement.dataset.index));
+}
+
+/**
+ * @param {HTMLElement} flaskElement
+*/
+function setFlaskClosed(flaskElement) {
+  flaskElement.setAttribute("aria-pressed", "false");
+  updateStatus("deselected", Number.parseInt(flaskElement.dataset.index));
+}
+
+function setAllFlasksClosed() {
+  flasksContainer.querySelectorAll('.flask').forEach((flaskElement) => {
+    flaskElement.setAttribute("aria-pressed", "false");
   });
+}
+
+/**
+ * @param {HTMLElement} flaskElement
+ */
+function selectFlask(flaskElement) {
+  const fromFlaskElement = /** @type {HTMLElement} */(flasksContainer.querySelector('[aria-pressed="true"]'));
+
+  if (!fromFlaskElement) {
+    // No flask is selected
+    setFlaskOpen(flaskElement);
+  } else if (fromFlaskElement === flaskElement) {
+    // Close the flask
+    setFlaskClosed(flaskElement);
+  } else {
+    // A different flask is selected, atempt to pour!
+    const fromIndex = Number.parseInt(fromFlaskElement.dataset.index);
+    const toIndex = Number.parseInt(flaskElement.dataset.index);
+
+    if (canPour(gameData[fromIndex], gameData[toIndex])) {
+      updateStatus("pour", fromIndex, toIndex);
+    } else {
+      updateStatus("failedToPour", fromIndex, toIndex);
+    }
+
+    pour(gameData[fromIndex], gameData[toIndex]);
+    setAllFlasksClosed();
+    updateFlasks();
+  }
 }
 
 function initializeFlasks() {
   for (let i = 0; i < gameData.length; i++) {
-    const flaskDiv = document.createElement("div");
-    flaskDiv.classList.add("flask");
-    flaskDiv.addEventListener("click", () => {
-      setFlaskOpen(i);
-    });
-    renderFlask(flaskDiv, gameData[i], i);
+    const flaskElement = document.createElement("button");
+    flaskElement.classList.add("flask");
+    flaskElement.dataset.index = i.toString();
+    setFlaskClosed(flaskElement);
 
-    flasksEl.appendChild(flaskDiv);
+    renderFlask(flaskElement, gameData[i]);
+
+    flasksContainer.appendChild(flaskElement);
   }
+
+  flasksContainer.addEventListener("click", (evt) => {
+    const target = /** @type {HTMLElement} */(evt.target);
+
+    if (target.matches(".flask")) {
+      selectFlask(target);
+    }
+  });
+
+  updateStatus("reset");
 }
+
 initializeFlasks();
 
 function isGameOver() {


### PR DESCRIPTION
Based on the logic provided by @evert on #1 for checking what to do next with each flask. The references were tweaked so the state is kept in the HTML instead of in JS land.

Added some better semantic markup to the content and specific ARIA roles so the game can be played with keyboard and a screen reader.

## List of changes
- The flask element is now a `button` to get free keyboard focus and interaction.
- The flask button has the `aria-pressed` attribute so it is also a toggle button and the state is kept by toggling that attribute.
- The segments are now in an ordered list. Although my test with NVDA didn't announce them that way, it is marked up as a list 🤷‍♂️.
- Added hover and focus states to the flasks.
- Added a description to the flasks.
- Updated the output to be a status, it uses the proper ARIA attributes to get messages announced.